### PR TITLE
[Perf/#32] 인덱스 추가 및 성능 테스트 진행

### DIFF
--- a/src/main/kotlin/learn_mate_it/dev/domain/chat/domain/repository/ChatRoomRepository.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/chat/domain/repository/ChatRoomRepository.kt
@@ -10,9 +10,14 @@ interface ChatRoomRepository: JpaRepository<ChatRoom, Long> {
 
     @Query(value = "SELECT cr " +
             "FROM ChatRoom cr " +
-            "LEFT JOIN FETCH cr.chats " +
             "WHERE cr.chatRoomId = :chatRoomId")
     fun findByChatRoomId(@Param(value = "chatRoomId") chatRoomId: Long): ChatRoom?
+
+    @Query(value = "SELECT cr " +
+            "FROM ChatRoom cr " +
+            "JOIN FETCH cr.chats " +
+            "WHERE cr.chatRoomId = :chatRoomId")
+    fun findByChatRoomIdFetchChats(@Param(value = "chatRoomId") chatRoomId: Long): ChatRoom?
 
     @Query(value = "SELECT cr " +
             "FROM ChatRoom cr " +
@@ -29,8 +34,8 @@ interface ChatRoomRepository: JpaRepository<ChatRoom, Long> {
 
     @Modifying
     @Query("DELETE " +
-                "FROM ChatRoom cr " +
-                "WHERE cr.userId IN :userId")
+            "FROM ChatRoom cr " +
+            "WHERE cr.userId IN :userId")
     fun deleteByUserId(@Param(value = "userId") userId: Long)
 
 }

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/application/service/impl/DiaryAnalysisServiceImpl.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/application/service/impl/DiaryAnalysisServiceImpl.kt
@@ -1,6 +1,8 @@
 package learn_mate_it.dev.domain.diary.application.service.impl
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
 import learn_mate_it.dev.common.exception.GeneralException
 import learn_mate_it.dev.common.status.ErrorStatus
 import learn_mate_it.dev.domain.diary.application.dto.response.DiaryDto

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingFeedbackRepository.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingFeedbackRepository.kt
@@ -15,9 +15,13 @@ interface SpellingFeedbackRepository : JpaRepository<SpellingFeedback, Long> {
     fun deleteByUserId(@Param(value = "userId") userId: Long)
 
     @Modifying
-    @Query("DELETE " +
-            "FROM SpellingFeedback sp " +
-            "WHERE sp.diary.diaryId IN :diaryId")
+    @Query(
+        nativeQuery = true,
+        value = """
+        DELETE FROM spelling_feedback 
+        WHERE diary_id = :diaryId
+    """
+    )
     fun deleteByDiaryId(@Param(value = "diaryId") diaryId: Long)
 
 }

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingRepository.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingRepository.kt
@@ -15,9 +15,13 @@ interface SpellingRepository : JpaRepository<Spelling, Long> {
     fun deleteByUserId(@Param(value = "userId") userId: Long)
 
     @Modifying
-    @Query("DELETE " +
-            "FROM Spelling s " +
-            "WHERE s.diary.diaryId IN :diaryId")
+    @Query(
+        nativeQuery = true,
+        value = """
+        DELETE FROM spelling 
+        WHERE diary_id = :diaryId
+    """
+    )
     fun deleteByDiaryId(@Param(value = "diaryId") diaryId: Long)
 
 }

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingRevisionRepository.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingRevisionRepository.kt
@@ -15,9 +15,17 @@ interface SpellingRevisionRepository : JpaRepository<SpellingRevision, Long> {
     fun deleteByUserId(@Param(value = "userId") userId: Long)
 
     @Modifying
-    @Query("DELETE " +
-            "FROM SpellingRevision sr " +
-            "WHERE sr.spelling.diary.diaryId IN :diaryId")
+    @Query(
+        nativeQuery = true,
+        value = """
+        DELETE FROM spelling_revision 
+        WHERE spelling_id IN (
+            SELECT spelling_id 
+            FROM spelling s 
+            WHERE diary_id = :diaryId
+        )
+    """
+    )
     fun deleteByDiaryId(@Param(value = "diaryId") diaryId: Long)
 
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,30 @@
+/**
+  Courses
+ */
+CREATE INDEX IF NOT EXISTS idx_user_step_progress_user_completed_partial
+    ON user_step_progress(user_id)
+    WHERE completed_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_user_step_progress_user_step_type_completed_partial
+    ON user_step_progress(user_id, step_type)
+    WHERE completed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_user_step_progress_id_user
+    ON user_step_progress(step_progress_id, user_id);
+
+/**
+  Chat
+ */
+CREATE INDEX IF NOT EXISTS idx_chat_chatroom_id
+    ON chat(chat_room_id);
+
+CREATE INDEX IF NOT EXISTS idx_chat_room_user_created_at_title_partial
+    ON chat_room(user_id, created_at DESC)
+    WHERE title IS NOT NULL;
+
+ /**
+   Diary
+  */
+CREATE INDEX IF NOT EXISTS idx_diary_user_created_diary
+    ON diary(user_id, created_at ASC, diary_id);
+


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #32 

## 💡 작업내용
#### 튜닝 이전 주요 조회 로직, 삭제 로직에 대한 성능 테스트 진행
- [Course] 홈 화면 조회(GET), 학습 시작하기(POST) 
- [Chat] 텍스트 대화하기(POST), 저장된 대화방 리스트 조회(GET)
- [Diary] 캘린더 조회(GET), 일기 작성(POST)

<br>

GET 요청은 동시에 **4000명**이 요청을 보낼 때의 시간 지표를 측정했습니다.
POST 요청은 Course 도메인을 제외하고는 동시에 **100명**이 요청을 보낼 때의 시간 지표를 측정했습니다.
각 테이블의 로우 개수는 Course, Diary의 경우 약 **8000개**, Chat의 경우 약 **1500개**로 정의합니다.
- 평균 요청 처리 시간
- 최소 요청 처리 시간
- 최대 요청 처리 시간
- 에러 발생 확률


#### 각 쿼리의 실행 계획 확인
- PostgreSQL의 `EXPLAIN ANALYZE`를 이용해 각 주요 쿼리의 실행 계획을 확인했습니다.


#### 인덱스 추가
- `resources/schema.sql` 파일에 parial index를 포함해 각 도메인에 필요한 인덱스 생성 쿼리를 작성했습니다.
-  각 칼럼에 대해 연산자 뿐만 아니라 `IS NOT NULL` 등의 조건을 더욱 활용하기 위해, JPA의 `@Index`가 아닌 실제 쿼리를 이용해 인덱스를 생성하는 방향을 선택했습니다.


#### 성능 개선 확인
- 인덱스 추가 및 쿼리 개선 이후 성능 지표를 재측정해 개선 정도를 확인했습니다.
- 보다 자세한 사항은 노션에 기재해두었습니다.

<br>

## 🤖 성능 개선 예시
#### 홈 화면 조회 쿼리 성능 측정
인덱스 추가 전 실행 계획
``` SQL
Seq Scan on user_step_progress usp1_0  (cost=0.00..173.11 rows=8 width=56) (actual time=0.028..1.332 rows=2 loops=1)
  Filter: ((completed_at IS NOT NULL) AND (user_id = 3))
  Rows Removed by Filter: 8007
Planning Time: 0.573 ms
Execution Time: 1.366 ms
```

인덱스 추가 후 실행 계획
``` SQL
Index Scan using idx_user_completed_partial on user_step_progress usp1_0  (cost=0.13..12.27 rows=8 width=56) (actual time=0.047..0.048 rows=2 loops=1)
  Index Cond: (user_id = 3)
Planning Time: 0.287 ms
Execution Time: 0.073 ms
```

적절한 partial 인덱스 추가로 인해 실행시간이 약 18배 감소한 것을 확인할 수 있습니다.

## 📝 기타
