### PR TITLE
[Chore/#37] 구글 로그인 토큰 리다이렉트 방식 변경

### DIFF
--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/handler/OAuthLoginSuccessHandler.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/handler/OAuthLoginSuccessHandler.kt
@@ -1,5 +1,6 @@
 package learn_mate_it.dev.domain.auth.handler
 
+import ApiResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -57,8 +58,8 @@ class OAuthLoginSuccessHandler(
         saveRefreshToken(refreshToken, user.userId)
 
         // set response
-        response!!.setHeader("accessToken", accessToken)
-        setHttpResponse(response)
+        val redirectUri = "com.learnmate.app://oauth2/callback?accessToken=$accessToken"
+        response?.sendRedirect(redirectUri)
     }
 
     private fun getOAuth2UserInfo(oAuthToken: OAuth2AuthenticationToken) : OAuth2UserInfo {


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #37 

## 💡 작업내용
- 기존 response header에 담았던 accessToken을 ios deep redirect link를 통해 파라미터로 전달하도록 수정했습니다.


## 📝 기타
