### PR TITLE
[Refactor/#45] Apple Login Request 및 UserInfo 수정

### DIFF
--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/application/dto/request/AuthRequest.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/application/dto/request/AuthRequest.kt
@@ -1,5 +1,6 @@
 package learn_mate_it.dev.domain.auth.application.dto.request
 
 data class AppleLoginRequest(
+    val username: String?,
     val identityToken: String
 )

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/application/service/AuthService.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/application/service/AuthService.kt
@@ -1,11 +1,12 @@
 package learn_mate_it.dev.domain.auth.application.service
 
+import learn_mate_it.dev.domain.auth.application.dto.request.AppleLoginRequest
 import org.springframework.security.core.Authentication
 
 
 interface AuthService {
 
-    fun authenticateWithApple(identityToken: String): Authentication
+    fun authenticateWithApple(request: AppleLoginRequest): Authentication
     fun reissueToken(refreshToken: String): String
     fun deleteRefreshToken(userId: Long)
     fun deleteRefreshToken(refreshToken: String)

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/application/service/impl/AuthServiceImpl.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/application/service/impl/AuthServiceImpl.kt
@@ -3,6 +3,7 @@ package learn_mate_it.dev.domain.auth.application.service.impl
 import io.jsonwebtoken.Claims
 import learn_mate_it.dev.common.exception.GeneralException
 import learn_mate_it.dev.common.status.ErrorStatus
+import learn_mate_it.dev.domain.auth.application.dto.request.AppleLoginRequest
 import learn_mate_it.dev.domain.auth.application.service.AppleClient
 import learn_mate_it.dev.domain.auth.application.service.AuthService
 import learn_mate_it.dev.domain.auth.domain.enums.TokenType
@@ -27,10 +28,16 @@ class AuthServiceImpl(
     private val appleClient: AppleClient
 ): AuthService {
 
-    override fun authenticateWithApple(identityToken: String): Authentication {
-        val claims = validateAppleToken(identityToken)
+    override fun authenticateWithApple(request: AppleLoginRequest): Authentication {
+        val claims = validateAppleToken(request.identityToken)
+
+        val attributes = claims.toMutableMap()
+        request.username?.let {
+            attributes["username"] = it
+        }
+
         val authorities = listOf(SimpleGrantedAuthority("ROLE_USER"))
-        val principal = DefaultOAuth2User(authorities, claims, "sub")
+        val principal = DefaultOAuth2User(authorities, attributes, "sub")
 
         return OAuth2AuthenticationToken(
             principal,

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/domain/dto/AppleUserInfo.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/domain/dto/AppleUserInfo.kt
@@ -11,7 +11,12 @@ class AppleUserInfo(
     }
 
     override fun getName(): String {
-        return attributes.get("email") as? String ?: "Apple"
+        val username = attributes["username"] as? String
+        if (username != null) {
+            return username
+        }
+
+        return (attributes["email"] as? String)?.substringBefore("@") ?: "Apple"
     }
 
     override fun getProvider(): String {

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/handler/OAuthLoginSuccessHandler.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/handler/OAuthLoginSuccessHandler.kt
@@ -59,7 +59,7 @@ class OAuthLoginSuccessHandler(
         saveRefreshToken(refreshToken, user.userId)
 
         // set response
-        val redirectUri = "com.learnmate.app://oauth2/callback?accessToken=$accessToken"
+        val redirectUri = "com.learnmate.app://oauth2/callback?accessToken=$accessToken?username=${user.username}"
         response?.sendRedirect(redirectUri)
     }
 

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/presentation/AuthController.kt
@@ -27,7 +27,7 @@ class AuthController(
         httpRequest: HttpServletRequest,
         httpResponse: HttpServletResponse
     ) {
-        val authentication = authService.authenticateWithApple(request.identityToken)
+        val authentication = authService.authenticateWithApple(request)
         oAuthLoginSuccessHandler.onAuthenticationSuccess(httpRequest, httpResponse, authentication)
     }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #45 

## ✨작업 배경
애플 로그인의 경우, identityToken에 user의 name이 포함되지 않아 DB의 username에 email이 저장되는 문제가 발생했습니다. 따라서, 해당 문제를 간접적으로 해결하기 위해, 회원가입 시 프론트로부터 username을 같이 받아 token이 유효하다면 해당 username을 DB에 저장하도록 수정합니다.

## 💡 작업내용
### 1. Request 수정
- `username: String?` 필드 추가
- `username` 필드가 존재할 시, claims에 `username` key 추가해 successHandler로 던짐

### 2. 로그인, 회원가입 로직 수정
- `AppleUserInfo`의 `getName()` 함수 수정
- `attributes`에 `username`이 존재할 경우, 해당 값 사용
- 존재하지 않을 경우, 기존 로직대로 email 값을 사용하며 @ 뒤의 값은 제거해 저장함 


## 📝 기타
