### PR TITLE
[Feat/#52] Logback 기반 Exception Discord 알림 전송 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,8 +23,13 @@ configurations {
 
 repositories {
 	mavenCentral()
+
 	maven {
 		url = uri("https://repo.spring.io/milestone")
+	}
+
+	maven {
+		url = uri("https://jitpack.io")
 	}
 }
 
@@ -59,6 +64,8 @@ dependencies {
 	// email
 	implementation ("org.springframework.boot:spring-boot-starter-mail")
 	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+	// discord
+	implementation("com.github.napstr:logback-discord-appender:1.0.0")
 
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")

--- a/src/main/kotlin/learn_mate_it/dev/common/base/BaseStatus.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/base/BaseStatus.kt
@@ -2,7 +2,7 @@ package learn_mate_it.dev.common.base
 
 import org.springframework.http.HttpStatus
 
-interface BaseErrorStatus {
+interface BaseStatus {
     val httpStatus: HttpStatus
     val code: String
     val message: String

--- a/src/main/kotlin/learn_mate_it/dev/common/base/BaseSuccessStatus.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/base/BaseSuccessStatus.kt
@@ -1,9 +1,0 @@
-package learn_mate_it.dev.common.base
-
-import org.springframework.http.HttpStatus
-
-interface BaseSuccessStatus {
-    val httpStatus: HttpStatus
-    val code: String
-    val message: String
-}

--- a/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralException.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralException.kt
@@ -1,7 +1,7 @@
 package learn_mate_it.dev.common.exception
 
-import learn_mate_it.dev.common.base.BaseErrorStatus
+import learn_mate_it.dev.common.base.BaseStatus
 
 class GeneralException(
-    val errorStatus: BaseErrorStatus
+    val errorStatus: BaseStatus
 ) : RuntimeException(errorStatus.message)

--- a/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -44,8 +45,15 @@ class GeneralExceptionAdvice : ResponseEntityExceptionHandler() {
     @ExceptionHandler(NullPointerException::class)
     fun handleNullPointerException(e: NullPointerException): ResponseEntity<ApiResponse<Nothing>> {
         val errorMessage = "서버에서 예기치 않은 오류가 발생했습니다. 요청을 처리하는 중에 Null 값이 참조되었습니다."
-        log.error(">>>>>>>>NullPointerException: $e")
+        log.error(">>>>>>>>NullPointerException: ", e)
         return ApiResponse.error(ErrorStatus.INTERNAL_SERVER_ERROR, errorMessage)
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    fun handleHttpRequestMethodNotSupported(e: HttpRequestMethodNotSupportedException): ResponseEntity<ApiResponse<Nothing>> {
+        val errorMessage = "지원하지 않는 HTTP 메소드 요청입니다: " + e.method
+        log.error(">>>>>>>>HttpRequestMethodNotSupportedException: ", e)
+        return ApiResponse.error(ErrorStatus.METHOD_NOT_ALLOWED, errorMessage)
     }
 
     @ExceptionHandler(IllegalArgumentException::class)

--- a/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
@@ -18,7 +18,7 @@ class GeneralExceptionAdvice : ResponseEntityExceptionHandler() {
 
     @ExceptionHandler(GeneralException::class)
     fun handleGeneralException(e: GeneralException): ResponseEntity<ApiResponse<Nothing>> {
-        log.error(">>>>>>>>GeneralException: ${e.message}")
+        log.error(">>>>>>>>GeneralException: ", e)
         return ApiResponse.error(e.errorStatus)
     }
 
@@ -37,27 +37,27 @@ class GeneralExceptionAdvice : ResponseEntityExceptionHandler() {
             message = errorMessage?: errorCode.message,
             data = null
         )
-        log.error(">>>>>>>>MethodArgumentNotValidException: ${ex.message}")
+        log.error(">>>>>>>>MethodArgumentNotValidException: ", ex)
         return handleExceptionInternal(ex, body, headers, status, request)
     }
 
     @ExceptionHandler(NullPointerException::class)
     fun handleNullPointerException(e: NullPointerException): ResponseEntity<ApiResponse<Nothing>> {
         val errorMessage = "서버에서 예기치 않은 오류가 발생했습니다. 요청을 처리하는 중에 Null 값이 참조되었습니다."
-        log.error(">>>>>>>>NullPointerException: ${e.message}")
+        log.error(">>>>>>>>NullPointerException: $e")
         return ApiResponse.error(ErrorStatus.INTERNAL_SERVER_ERROR, errorMessage)
     }
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ApiResponse<Nothing>> {
         val errorMessage = "잘못된 요청입니다: " + e.message
-        log.error(">>>>>>>>IllegalArgumentException: ${e.message}")
+        log.error(">>>>>>>>IllegalArgumentException: ", e)
         return ApiResponse.error(ErrorStatus.BAD_REQUEST, errorMessage)
     }
 
     @ExceptionHandler(Exception::class)
     fun handleException(e: Exception): ResponseEntity<ApiResponse<Nothing>> {
-        log.error(">>>>>>>>Internal Server Error: {}", e.message)
+        log.error(">>>>>>>>Internal Server Error: ", e)
         return ApiResponse.error(ErrorStatus.INTERNAL_SERVER_ERROR)
     }
 

--- a/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
@@ -18,7 +18,7 @@ class GeneralExceptionAdvice : ResponseEntityExceptionHandler() {
 
     @ExceptionHandler(GeneralException::class)
     fun handleGeneralException(e: GeneralException): ResponseEntity<ApiResponse<Nothing>> {
-        log.warn(">>>>>>>>GeneralException: ${e.message}")
+        log.error(">>>>>>>>GeneralException: ${e.message}")
         return ApiResponse.error(e.errorStatus)
     }
 
@@ -37,7 +37,28 @@ class GeneralExceptionAdvice : ResponseEntityExceptionHandler() {
             message = errorMessage?: errorCode.message,
             data = null
         )
+        log.error(">>>>>>>>MethodArgumentNotValidException: ${ex.message}")
         return handleExceptionInternal(ex, body, headers, status, request)
+    }
+
+    @ExceptionHandler(NullPointerException::class)
+    fun handleNullPointerException(e: NullPointerException): ResponseEntity<ApiResponse<Nothing>> {
+        val errorMessage = "서버에서 예기치 않은 오류가 발생했습니다. 요청을 처리하는 중에 Null 값이 참조되었습니다."
+        log.error(">>>>>>>>NullPointerException: ${e.message}")
+        return ApiResponse.error(ErrorStatus.INTERNAL_SERVER_ERROR, errorMessage)
+    }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ApiResponse<Nothing>> {
+        val errorMessage = "잘못된 요청입니다: " + e.message
+        log.error(">>>>>>>>IllegalArgumentException: ${e.message}")
+        return ApiResponse.error(ErrorStatus.BAD_REQUEST, errorMessage)
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception): ResponseEntity<ApiResponse<Nothing>> {
+        log.error(">>>>>>>>Internal Server Error: {}", e.message)
+        return ApiResponse.error(ErrorStatus.INTERNAL_SERVER_ERROR)
     }
 
 }

--- a/src/main/kotlin/learn_mate_it/dev/common/response/ApiResponse.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/response/ApiResponse.kt
@@ -1,8 +1,7 @@
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
-import learn_mate_it.dev.common.base.BaseErrorStatus
-import learn_mate_it.dev.common.base.BaseSuccessStatus
+import learn_mate_it.dev.common.base.BaseStatus
 import org.springframework.http.ResponseEntity
 
 @JsonPropertyOrder("isSuccess", "code", "message", "data")
@@ -16,25 +15,25 @@ data class ApiResponse<T>(
     val data: T? = null
 ) {
     companion object {
-        fun success(successStatus: BaseSuccessStatus): ResponseEntity<ApiResponse<Nothing>> {
+        fun success(successStatus: BaseStatus): ResponseEntity<ApiResponse<Nothing>> {
             return ResponseEntity
                 .status(successStatus.httpStatus)
                 .body(ApiResponse(true, successStatus.code, successStatus.message, null))
         }
 
-        fun <T> success(successStatus: BaseSuccessStatus, data: T): ResponseEntity<ApiResponse<T>> {
+        fun <T> success(successStatus: BaseStatus, data: T): ResponseEntity<ApiResponse<T>> {
             return ResponseEntity
                 .status(successStatus.httpStatus)
                 .body(ApiResponse(true, successStatus.code, successStatus.message, data))
         }
 
-        fun error(errorStatus: BaseErrorStatus): ResponseEntity<ApiResponse<Nothing>> {
+        fun error(errorStatus: BaseStatus): ResponseEntity<ApiResponse<Nothing>> {
             return ResponseEntity
                 .status(errorStatus.httpStatus)
                 .body(ApiResponse(false, errorStatus.code, errorStatus.message, null))
         }
 
-        fun error(errorStatus: BaseErrorStatus, message: String): ResponseEntity<ApiResponse<Nothing>> {
+        fun error(errorStatus: BaseStatus, message: String): ResponseEntity<ApiResponse<Nothing>> {
             return ResponseEntity
                 .status(errorStatus.httpStatus)
                 .body(ApiResponse(false, errorStatus.code, message, null))

--- a/src/main/kotlin/learn_mate_it/dev/common/status/ErrorStatus.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/status/ErrorStatus.kt
@@ -1,13 +1,13 @@
 package learn_mate_it.dev.common.status
 
-import learn_mate_it.dev.common.base.BaseErrorStatus
+import learn_mate_it.dev.common.base.BaseStatus
 import org.springframework.http.HttpStatus
 
 enum class ErrorStatus (
     override val httpStatus: HttpStatus,
     override val code: String,
     override val message: String
-) : BaseErrorStatus {
+) : BaseStatus {
 
     /**
      * Common

--- a/src/main/kotlin/learn_mate_it/dev/common/status/SuccessStatus.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/status/SuccessStatus.kt
@@ -1,13 +1,13 @@
 package learn_mate_it.dev.common.status
 
-import learn_mate_it.dev.common.base.BaseSuccessStatus
+import learn_mate_it.dev.common.base.BaseStatus
 import org.springframework.http.HttpStatus
 
 enum class SuccessStatus (
     override val httpStatus: HttpStatus,
     override val code: String,
     override val message: String
-) : BaseSuccessStatus {
+) : BaseStatus {
 
     OK(HttpStatus.OK, "200", "요청이 성공적으로 처리되었습니다."),
 

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/handler/AccessHandler.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/handler/AccessHandler.kt
@@ -3,7 +3,7 @@ package learn_mate_it.dev.domain.auth.handler
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import learn_mate_it.dev.common.base.BaseErrorStatus
+import learn_mate_it.dev.common.base.BaseStatus
 import learn_mate_it.dev.common.status.ErrorStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.AccessDeniedException
@@ -36,7 +36,7 @@ class AccessDeniedHandler: AccessDeniedHandler {
     }
 }
 
-private fun setHttpResponse(errorStatus: BaseErrorStatus, response: HttpServletResponse) {
+private fun setHttpResponse(errorStatus: BaseStatus, response: HttpServletResponse) {
     val mapper = ObjectMapper()
     response.contentType = MediaType.APPLICATION_JSON_VALUE
     response.characterEncoding = "UTF-8"

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/handler/OAuthLoginFailureHandler.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/handler/OAuthLoginFailureHandler.kt
@@ -3,7 +3,7 @@ package learn_mate_it.dev.domain.auth.handler
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import learn_mate_it.dev.common.base.BaseErrorStatus
+import learn_mate_it.dev.common.base.BaseStatus
 import learn_mate_it.dev.common.status.ErrorStatus
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
@@ -27,7 +27,7 @@ class OAuthLoginFailureHandler: AuthenticationFailureHandler {
         setHttpResponse(errorStatus, response)
     }
 
-    private fun setHttpResponse(errorStatus: BaseErrorStatus, response: HttpServletResponse) {
+    private fun setHttpResponse(errorStatus: BaseStatus, response: HttpServletResponse) {
         val mapper = ObjectMapper()
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.characterEncoding = "UTF-8"

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/jwt/JwtFilter.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/jwt/JwtFilter.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import learn_mate_it.dev.common.base.BaseErrorStatus
+import learn_mate_it.dev.common.base.BaseStatus
 import learn_mate_it.dev.common.exception.GeneralException
 import learn_mate_it.dev.common.status.ErrorStatus
 import learn_mate_it.dev.domain.auth.domain.enums.TokenType
@@ -59,7 +59,7 @@ class JwtFilter(
         }
     }
 
-    private fun handleGeneralJwtError(errorStatus: BaseErrorStatus, response: HttpServletResponse) {
+    private fun handleGeneralJwtError(errorStatus: BaseStatus, response: HttpServletResponse) {
         val errorResponse = ApiResponse.error(errorStatus).body!!
         setHttpServletResponse(errorStatus.httpStatus.value(), errorResponse, response)
     }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,7 +6,7 @@
 
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <Pattern>[%d{HH:mm:ss}] [%thread] [%-5level] %logger{36} %n %msg%n```%ex{full}```</Pattern>
+                <Pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%t] %logger{36} - %msg%n</Pattern>
                 <charset>utf8</charset>
             </encoder>
         </appender>
@@ -24,7 +24,7 @@
         <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
             <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>[%d{HH:mm:ss}] [%thread] [%-5level] %logger{36} %n %msg%n```%ex{full}```</pattern>
+                <pattern>[%d{HH:mm:ss}] [%-5level] %logger{36} %n %msg%n```%ex{full}```</pattern>
             </layout>
             <username>[LearnMate]DEV SERVER ERROR</username>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,55 @@
+<configuration>
+
+    <!--local log-->
+    <springProfile name="local">
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <Pattern>[%d{HH:mm:ss}] [%thread] [%-5level] %logger{36} %n %msg%n```%ex{full}```</Pattern>
+                <charset>utf8</charset>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <!--dev log-->
+    <springProfile name="dev">
+        <property resource="application-secret.yml"/>
+        <springProperty name="DISCORD_WEBHOOK_URL" source="logging.discord.web-hook-url"/>
+
+        <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+            <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>[%d{HH:mm:ss}] [%thread] [%-5level] %logger{36} %n %msg%n```%ex{full}```</pattern>
+            </layout>
+            <username>[LearnMate]DEV SERVER ERROR</username>
+
+            <tts>false</tts>
+        </appender>
+
+        <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="DISCORD" />
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
+
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <Pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%t] %logger{36} - %msg%n</Pattern>
+                <charset>utf8</charset>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_DISCORD"/>
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+
+</configuration>


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #52 

## 💡 작업내용
### 1. 디스코드 연결
- web hook uri 연결
- `application-secret.yml`에서 환경변수로 uri 관리

### 2. Logback 커스텀
- local
  - console 로그 프린트 
- dev
  - console 로그 프린트
  - 디스코드 알림 전송 

### 3. Exception Handling
- Exception Handling Advice 구체화
- `NullPointerException`
- `HttpRequestMethodNotSupportedException`
- `IllegalArgumentException`
- `Exception`


## 📸 스크린샷(선택)
<img width="914" height="417" alt="스크린샷 2025-08-25 오후 6 37 51" src="https://github.com/user-attachments/assets/c15c0e70-0386-4bfa-8981-98bcc4d0f574" />


