### PR TITLE
[Feat/#52] GeneralException Log Level 분기 처리

### DIFF
--- a/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
@@ -20,7 +20,10 @@ class GeneralExceptionAdvice : ResponseEntityExceptionHandler() {
 
     @ExceptionHandler(GeneralException::class)
     fun handleGeneralException(e: GeneralException): ResponseEntity<ApiResponse<Nothing>> {
-        log.error(">>>>>>>>GeneralException: ", e)
+        when {
+            e.errorStatus.httpStatus.is5xxServerError -> log.error(">>>>>>>>GeneralException: ", e)
+            else -> log.warn(">>>>>>>>GeneralException: ", e)
+        }
         return ApiResponse.error(e.errorStatus)
     }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #52

## ✨ 작업 배경
앞선 PR에서, 예외 발생 시 ERROR 로그를 찍고 그 로그를 디스코드로 알림을 보내도록 설정함
이 때, `GeneralException`의 경우 알림이 필요없는 4xx 예외까지 알림을 받게 됨
따라서 4xx 예외의 로그 레벨을 변경해, 개발자에게 필요한 5xx 예외에 대한 알림만 전송될 수 있도록 변경함

## 💡 작업내용
### 1. Log Level 분리
- `GeneralException`의 `HttpStatus`에 따라 Log Level 분리
- 5xx 에러일 경우, ERROR 레벨 등록
- 그 외의 에러일 경우, WARN 레벨 등록



