### PR TITLE
[Refactor/#57] AI 호출 및 결과 파싱 로직 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,8 +67,6 @@ dependencies {
 	// discord
 	implementation("com.github.napstr:logback-discord-appender:1.0.0")
 
-	compileOnly("org.projectlombok:lombok")
-	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
@@ -22,7 +22,7 @@ class GeneralExceptionAdvice : ResponseEntityExceptionHandler() {
     fun handleGeneralException(e: GeneralException): ResponseEntity<ApiResponse<Nothing>> {
         when {
             e.errorStatus.httpStatus.is5xxServerError -> log.error(">>>>>>>>GeneralException: ", e)
-            else -> log.warn(">>>>>>>>GeneralException: ", e)
+            else -> log.warn(">>>>>>>>GeneralException: $e")
         }
         return ApiResponse.error(e.errorStatus)
     }

--- a/src/main/kotlin/learn_mate_it/dev/domain/chat/infra/application/dto/response/ChatAnalysisResponse.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/chat/infra/application/dto/response/ChatAnalysisResponse.kt
@@ -1,11 +1,10 @@
 package learn_mate_it.dev.domain.chat.infra.application.dto.response
 
+import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
 
-data class ChatRoomAnalysisDto(
-    @JsonProperty("title")
-    val title: String,
-    @JsonProperty("chatList")
-    val chatList: Map<String, String>
+data class ChatRoomAnalysisDto @JsonCreator constructor(
+    @JsonProperty("title") val title: String,
+    @JsonProperty("chatList") val chatList: Map<String, String>
 )

--- a/src/main/kotlin/learn_mate_it/dev/domain/chat/infra/application/service/ChatAiServiceImpl.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/chat/infra/application/service/ChatAiServiceImpl.kt
@@ -1,13 +1,13 @@
 package learn_mate_it.dev.domain.chat.infra.application.service
 
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.ObjectMapper
 import learn_mate_it.dev.common.exception.GeneralException
 import learn_mate_it.dev.common.status.ErrorStatus
 import learn_mate_it.dev.common.util.ResourceLoader
 import learn_mate_it.dev.domain.chat.application.dto.response.ChatDto
 import learn_mate_it.dev.domain.chat.application.service.ChatAiService
 import learn_mate_it.dev.domain.chat.infra.application.dto.response.ChatRoomAnalysisDto
+import org.slf4j.LoggerFactory
+import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.openai.OpenAiChatModel
 import org.springframework.stereotype.Service
 
@@ -15,9 +15,10 @@ import org.springframework.stereotype.Service
 class ChatAiServiceImpl(
     private val chatModel: OpenAiChatModel,
     private val resourceLoader: ResourceLoader,
-    private val objectMapper: ObjectMapper
 ) : ChatAiService {
 
+    private val chatClient = ChatClient.builder(chatModel).build()
+    private val log = LoggerFactory.getLogger("Logger")
     private val RECOMMEND_SUBJECT_PROMPT: String = resourceLoader.getResourceContent("recommend-subject-prompt.txt")
     private val CHAT_PROMPT = resourceLoader.getResourceContent("chat-prompt.txt")
     private val ANALYSIS_CHAT_PROMPT = resourceLoader.getResourceContent("analysis-chat-prompt.txt")
@@ -42,19 +43,14 @@ class ChatAiServiceImpl(
 
     override fun analysisChatRoom(chatList: List<ChatDto>): ChatRoomAnalysisDto {
         try {
-            val response = chatModel.call(ANALYSIS_CHAT_PROMPT + chatList.toString())
-            return parseAiResponse<ChatRoomAnalysisDto>(response)
+            return chatClient.prompt()
+                .user(ANALYSIS_CHAT_PROMPT + chatList.toString())
+                .call()
+                .entity(ChatRoomAnalysisDto::class.java)
         } catch (e: Exception) {
+            log.error("[*] AI 채팅방 내용 요약 요청 중 오류 발생 : ", e)
             throw GeneralException(ErrorStatus.CHAT_AI_ANALYSIS_ERROR)
         }
     }
 
-    private inline fun <reified T> parseAiResponse(aiResponse: String): T {
-        return try {
-            val cleanResponse = aiResponse.replace("```json\\s*".toRegex(), "").replace("```".toRegex(), "");
-            objectMapper.readValue(cleanResponse, T::class.java)
-        } catch (e: JsonProcessingException) {
-            throw GeneralException(ErrorStatus.CHAT_AI_PARSING_ERROR)
-        }
-    }
 }

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/application/service/impl/DiaryServiceImpl.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/application/service/impl/DiaryServiceImpl.kt
@@ -115,7 +115,7 @@ class DiaryServiceImpl(
      */
     @Transactional
     override fun deleteDiary(userId: Long, diaryId: Long) {
-        val diary = getDiary(diaryId)
+        val diary = getDiaryFetchSpelling(diaryId)
         diary.validIsUserAuthorized(userId)
 
         spellingService.deleteByDiaryId(diaryId)
@@ -128,11 +128,6 @@ class DiaryServiceImpl(
         spellingService.deleteByUserId(userId)
         feedbackService.deleteByUserId(userId)
         diaryRepository.deleteByUserId(userId)
-    }
-
-    private fun getDiary(diaryId: Long): Diary {
-        return diaryRepository.findByDiaryId(diaryId)
-            ?: throw GeneralException(ErrorStatus.NOT_FOUND_DIARY)
     }
 
 }

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/enums/SpellingCategory.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/enums/SpellingCategory.kt
@@ -8,9 +8,8 @@ enum class SpellingCategory(
     val weight: Double
 ) {
 
-    GRAMMAR("문법 오류", 1.5), WORD("단어 규칙 위반", 1.0), SPACING("띄어쓰기", 0.8),
-    STANDARD("표준어 위반", 0.8), TYPO("오탈자", 1.0), FOREIGN_WORD("외래어 표기법", 0.5),
-    SENTENCE("문장 오류", 1.3), ETC("기타", 1.0);
+    GRAMMAR("맞춤법", 1.5), SPACING("띄어쓰기", 0.8),
+    STANDARD("표준어 위반", 0.8), ETC("기타", 1.0);
 
     companion object {
         fun from(category: String): SpellingCategory {

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/DiaryRepository.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/DiaryRepository.kt
@@ -23,13 +23,6 @@ interface DiaryRepository : JpaRepository<Diary, Long> {
 
     @Query("SELECT d " +
             "FROM Diary d " +
-            "WHERE d.diaryId = :diaryId")
-    fun findByDiaryId(
-        @Param("diaryId") diaryId: Long
-    ): Diary?
-
-    @Query("SELECT d " +
-            "FROM Diary d " +
                 "LEFT JOIN FETCH d.spelling s " +
                 "LEFT JOIN FETCH s.revisions sr " +
                 "LEFT JOIN FETCH d.spellingFeedback sf " +

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingFeedbackRepository.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingFeedbackRepository.kt
@@ -15,13 +15,9 @@ interface SpellingFeedbackRepository : JpaRepository<SpellingFeedback, Long> {
     fun deleteByUserId(@Param(value = "userId") userId: Long)
 
     @Modifying
-    @Query(
-        nativeQuery = true,
-        value = """
-        DELETE FROM spelling_feedback 
-        WHERE diary_id = :diaryId
-    """
-    )
+    @Query("DELETE " +
+            "FROM SpellingFeedback sf " +
+            "WHERE sf.diary.diaryId = :diaryId")
     fun deleteByDiaryId(@Param(value = "diaryId") diaryId: Long)
 
 }

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingRepository.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingRepository.kt
@@ -15,13 +15,9 @@ interface SpellingRepository : JpaRepository<Spelling, Long> {
     fun deleteByUserId(@Param(value = "userId") userId: Long)
 
     @Modifying
-    @Query(
-        nativeQuery = true,
-        value = """
-        DELETE FROM spelling 
-        WHERE diary_id = :diaryId
-    """
-    )
+    @Query("DELETE " +
+            "FROM Spelling s " +
+            "WHERE s.diary.diaryId = :diaryId")
     fun deleteByDiaryId(@Param(value = "diaryId") diaryId: Long)
 
 }

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingRevisionRepository.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/domain/repository/SpellingRevisionRepository.kt
@@ -15,16 +15,12 @@ interface SpellingRevisionRepository : JpaRepository<SpellingRevision, Long> {
     fun deleteByUserId(@Param(value = "userId") userId: Long)
 
     @Modifying
-    @Query(
-        nativeQuery = true,
-        value = """
-        DELETE FROM spelling_revision 
-        WHERE spelling_id IN (
-            SELECT spelling_id 
-            FROM spelling s 
-            WHERE diary_id = :diaryId
-        )
-    """
+    @Query("DELETE " +
+            "FROM SpellingRevision sr " +
+            "WHERE sr.spelling.spellingId IN ( " +
+                "SELECT s.spellingId " +
+                "FROM Spelling s " +
+                "WHERE s.diary.diaryId = :diaryId )"
     )
     fun deleteByDiaryId(@Param(value = "diaryId") diaryId: Long)
 

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/infra/application/dto/response/SpellingAnalysisResponse.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/infra/application/dto/response/SpellingAnalysisResponse.kt
@@ -1,33 +1,36 @@
 package learn_mate_it.dev.domain.diary.infra.application.dto.response
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
 
-data class SpellingAnalysisResponse(
-    val origin: String,
-    val revised: String,
-    val revisedSentences: List<RevisedSentence>?
+
+data class SpellingAnalysisResponse @JsonCreator constructor(
+    @JsonProperty("origin") val origin: String,
+    @JsonProperty("revised") val revised: String,
+    @JsonProperty("revisedSentences") val revisedSentences: List<RevisedSentence>?
 )
 
-data class RevisedSentence(
-    val origin: String,
-    val revised: String,
-    val revisedBlocks: List<RevisedBlock>?,
+data class RevisedSentence @JsonCreator constructor(
+    @JsonProperty("origin") val origin: String,
+    @JsonProperty("revised") val revised: String,
+    @JsonProperty("revisedBlocks") val revisedBlocks: List<RevisedBlock>?,
 )
 
-data class RevisedBlock(
-    val origin: Origin,
-    val revised: String,
-    val revisions: List<Revision>
+data class RevisedBlock @JsonCreator constructor(
+    @JsonProperty("origin") val origin: Origin,
+    @JsonProperty("revised") val revised: String,
+    @JsonProperty("revisions") val revisions: List<Revision>
 )
 
-data class Origin(
-    val content: String,
-    val beginOffset: Int,
-    val length: Int
+data class Origin @JsonCreator constructor(
+    @JsonProperty("content") val content: String,
+    @JsonProperty("beginOffset") val beginOffset: Int,
+    @JsonProperty("length") val length: Int
 )
 
-data class Revision(
-    val revised: String,
-    val category: String,
-    val comment: String,
-    val examples: List<String>
+data class Revision @JsonCreator constructor(
+    @JsonProperty("revised") val revised: String,
+    @JsonProperty("category") val category: String,
+    @JsonProperty("comment") val comment: String,
+    @JsonProperty("examples") val examples: List<String>
 )

--- a/src/main/kotlin/learn_mate_it/dev/domain/diary/infra/application/service/SpellingAnalysisServiceImpl.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/diary/infra/application/service/SpellingAnalysisServiceImpl.kt
@@ -1,7 +1,5 @@
 package learn_mate_it.dev.domain.diary.infra.application.service
 
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import learn_mate_it.dev.common.exception.GeneralException
@@ -10,36 +8,30 @@ import learn_mate_it.dev.common.util.ResourceLoader
 import learn_mate_it.dev.domain.diary.application.service.SpellingAnalysisService
 import learn_mate_it.dev.domain.diary.infra.application.dto.response.SpellingAnalysisResponse
 import org.slf4j.LoggerFactory
+import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.openai.OpenAiChatModel
 import org.springframework.stereotype.Service
 
 @Service
 class SpellingAnalysisServiceImpl(
     private val chatModel: OpenAiChatModel,
-    private val resourceLoader: ResourceLoader,
-    private val objectMapper: ObjectMapper
+    private val resourceLoader: ResourceLoader
 ): SpellingAnalysisService {
 
+    private val chatClient = ChatClient.builder(chatModel).build()
     private val log = LoggerFactory.getLogger("Logger")
     private val ANALYSIS_SPELLING_PROMPT = resourceLoader.getResourceContent("analysis-spelling-prompt.txt")
 
     override suspend fun postAnalysisSpelling(content: String): SpellingAnalysisResponse = withContext(Dispatchers.IO) {
         try {
-            val response = chatModel.call(ANALYSIS_SPELLING_PROMPT + content)
-            parseAiResponse(response)
+            chatClient.prompt()
+                .user(ANALYSIS_SPELLING_PROMPT + content)
+                .call()
+                .entity(SpellingAnalysisResponse::class.java)
         } catch (e: Exception) {
             log.error("[*] AI 맞춤법 검사 요청 중 오류 발생 : ", e)
             throw GeneralException(ErrorStatus.ANALYSIS_SPELLING_SERVER_ERROR)
         }
     }
 
-    private inline fun <reified T> parseAiResponse(aiResponse: String): T {
-        return try {
-            val cleanResponse = aiResponse.replace("```json\\s*".toRegex(), "").replace("```".toRegex(), "");
-            objectMapper.readValue(cleanResponse, T::class.java)
-        } catch (e: JsonProcessingException) {
-            log.error("[*] AI 맞춤법 검사 결과 파싱 중 오류 발생 : ", e)
-            throw GeneralException(ErrorStatus.ANALYSIS_SPELLING_AI_PARSING_ERROR)
-        }
-    }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #57 

## 💡 작업내용
### 1. ChatClient
- 기존 : `chatModel.call()` 후 직접 `ObjectMapper` 이용해 결과 파싱
- 변경 : chatClient 빌드 후, `user(PROMPT).call()` 수행 및 `entity()`로 파싱할 결과 데이터 구조 명시
- 기존에는 프롬프팅에 직접 응답 구조를 명시하고 직접 파싱했으나, `entity()`를 이용함으로서 파싱 에러 위험 감소 및 외부 API 호출 과정에서 소모되는 토큰이 감소함
- `entity()`에 전달되는 class는 no-arg 생성자가 필요함
  - `@JsonCreator constructor` 이용하고 `@JsonProperty` 로 필드 맵핑 명시
  -   kotlin의 no-arg plugin 이용하려 시도했으나 실패함

### 2. SpellingCategory
- 프론트의 요청으로 맞춤법 검사 카테고리 축소

