### PR TITLE
[Refactor/#59] 이메일 인증 코드 전송 로직 Race Condition 방지 및 트랜잭션 분리

### DIFF
--- a/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
+++ b/src/main/kotlin/learn_mate_it/dev/common/exception/GeneralExceptionAdvice.kt
@@ -35,7 +35,7 @@ class GeneralExceptionAdvice : ResponseEntityExceptionHandler() {
         val errorMessage = ex.bindingResult.fieldErrors.firstOrNull()?.defaultMessage
         val body = createErrorBody(errorMessage, ErrorStatus.BAD_REQUEST)
 
-        log.warn(">>>>>>>>MethodArgumentNotValidException: ", ex)
+        log.warn(">>>>>>>>MethodArgumentNotValidException: $ex")
         return handleExceptionInternal(ex, body, headers, status, request)
     }
 

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/application/listener/EmailSendEvent.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/application/listener/EmailSendEvent.kt
@@ -1,0 +1,6 @@
+package learn_mate_it.dev.domain.auth.application.listener
+
+data class EmailSendEvent(
+    val email: String,
+    val code: String
+)

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/application/listener/EmailSendListener.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/application/listener/EmailSendListener.kt
@@ -1,0 +1,20 @@
+package learn_mate_it.dev.domain.auth.application.listener
+
+import learn_mate_it.dev.domain.auth.infra.application.service.EmailSendService
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class EmailSendListener(
+    val emailSendService: EmailSendService
+) {
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleEmailSendEvent(event: EmailSendEvent) {
+        emailSendService.sendEmail(event.email, event.code)
+    }
+
+}

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/application/service/impl/EmailVerificationServiceImpl.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/application/service/impl/EmailVerificationServiceImpl.kt
@@ -3,16 +3,17 @@ package learn_mate_it.dev.domain.auth.application.service.impl
 import jakarta.transaction.Transactional
 import learn_mate_it.dev.common.exception.GeneralException
 import learn_mate_it.dev.common.status.ErrorStatus
+import learn_mate_it.dev.domain.auth.application.listener.EmailSendEvent
 import learn_mate_it.dev.domain.auth.application.service.EmailVerificationService
 import learn_mate_it.dev.domain.auth.domain.model.EmailVerification
 import learn_mate_it.dev.domain.auth.domain.repository.EmailVerificationRepository
-import learn_mate_it.dev.domain.auth.infra.application.service.EmailSendService
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
 @Service
 class EmailVerificationServiceImpl(
-    private val emailSendService: EmailSendService,
-    private val emailVerificationRepository: EmailVerificationRepository
+    private val emailVerificationRepository: EmailVerificationRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ): EmailVerificationService {
 
     /**
@@ -27,7 +28,7 @@ class EmailVerificationServiceImpl(
         verification.updateCode(code)
         emailVerificationRepository.save(verification)
 
-        emailSendService.sendEmail(email, code)
+        applicationEventPublisher.publishEvent(EmailSendEvent(email, code))
     }
 
     private fun createVerificationCode() = (100000..999999).random().toString()
@@ -54,7 +55,7 @@ class EmailVerificationServiceImpl(
     @Transactional
     override fun validateIsEmailVerified(email: String) {
         val verification = getEmailVerificationByEmail(email)
-        verification.ensureIsNotVerified()
+        verification.ensureIsVerified()
 
         emailVerificationRepository.delete(verification)
     }

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/domain/model/EmailVerification.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/domain/model/EmailVerification.kt
@@ -21,7 +21,7 @@ data class EmailVerification(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val emailVerificationId: Long = 0L
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     var isVerified: Boolean = false
 
     fun verify() {
@@ -37,7 +37,7 @@ data class EmailVerification(
         return LocalDateTime.now().isAfter(expirationTime)
     }
 
-    fun ensureIsNotVerified() {
+    fun ensureIsVerified() {
         if (!this.isVerified) {
             throw GeneralException(ErrorStatus.EMAIL_IS_NOT_VERIFIED)
         }

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/domain/repository/EmailVerificationRepository.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/domain/repository/EmailVerificationRepository.kt
@@ -1,8 +1,11 @@
 package learn_mate_it.dev.domain.auth.domain.repository
 
+import jakarta.persistence.LockModeType
 import learn_mate_it.dev.domain.auth.domain.model.EmailVerification
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 
 interface EmailVerificationRepository: JpaRepository<EmailVerification, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun findByEmail(email: String): EmailVerification?
 }

--- a/src/main/kotlin/learn_mate_it/dev/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/learn_mate_it/dev/domain/auth/presentation/AuthController.kt
@@ -23,11 +23,6 @@ class AuthController(
     private val oAuthLoginSuccessHandler: OAuthLoginSuccessHandler
 ) {
 
-    @GetMapping("/discord-test")
-    fun discordTest() {
-        throw Exception("Discord Error Test")
-    }
-
     @PostMapping("/apple/login")
     fun appleLogin(
         @RequestBody request: AppleLoginRequest,


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #59 

<br>

## 🤷 작업배경
기존 email verification 인증 로직은 다음과 같습니다.
  1. email을 받아 해당 email 주소를 가지고 있는 entity가 있는지 조회
  2. 없으면 새로 생성, 있으면 해당 entity 사용
  3. code 생성 후 entity 필드값 업데이트 및 저장
  4. confirm 요청이 올 경우, 1번 수행
  5. 해당 entity에 저장된 code와 동일한지 확인 + 유효시간 5분 확인
  6. 코드가 동일하고 유효하다면 인증 성공


발견된 문제점은 다음과 같습니다.

1. 유저가 요청을 동시에 여러 번 반복하거나 쓰레드 간 경쟁 상태가 일어날 경우, 
  앞선 조건을 만족하지 않는 상황이 발생하며 1번에서 entity를 조회할 때 2개 이상의 entity가 조회되어 Exception이 발생하며, 인증이 실패합니다.
2. 메일 전송 로직이 entity 저장 로직과 같은 트랜잭션 내에 존재해,
  쓰레드 점유 시간이 불필요하게 길고 정합성 보장이 어렵습니다.

<br>

## 💡 작업내용
#### 1. Unique 칼럼 지정
- `EmailVerification` entity의 email 칼럼은 **unique**로 지정해 1번 문제를 방지
#### 2. 메일 전송 로직 트랜잭션 분리
- Event, Listener을 이용해 저장 로직과 메일 전송 로직 분리
- `TransactionPhase.AFTER_COMMIT`을 이용해 entity 저장 및 커밋이 완료된 후 메일 전송
- `@Async` 이용해 쓰레드를 별도로 분리하여 응답시간 단축
#### 3. WRITE LOCK 적용
- repository에서 email 주소를 이용해 entity를 찾는 함수에 `@Lock(LockModeType.PESSIMISTIC_WRITE)` 추가해 경쟁상태 방지



